### PR TITLE
[SETUP] Add "skip_cleanup" to fix deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
 deploy:
   - provider: script
     script: "./bin/deploy.sh"
+    skip_cleanup: true
     on:
       branch: master
 


### PR DESCRIPTION
Travis clears changes prior to deployment, meaning we lose `node_modules`.