### PR TITLE
[BUG] Change LaunchRequest to keep session open

### DIFF
--- a/alexa/handlers/launch-request.js
+++ b/alexa/handlers/launch-request.js
@@ -1,9 +1,16 @@
 module.exports = function() {
-    this.emit(
-        ':tell',
+    const speech =
         '<p>You can ask me about available drinks at Tiny Rebel bars in either Cardiff or Newport.</p>' +
-            '<p>I can <emphasis level="reduced">suggest</emphasis> a drink, ' +
-            'find you the <emphasis level="moderate">cheapest</emphasis> drink, ' +
-            'or find you the strongest drink.</p>'
-    );
+        '<p>I can <emphasis level="reduced">suggest</emphasis> a drink, ' +
+        'find you the <emphasis level="moderate">cheapest</emphasis> drink, ' +
+        'or find you the strongest drink.</p>' +
+        '<p>What would you like me to do?</p>';
+
+    const repromptSpeech =
+        '<p>You can ask me to <emphasis level="reduced">suggest</emphasis> a drink, ' +
+        'find you the <emphasis level="moderate">cheapest</emphasis> drink, ' +
+        'or find you the strongest drink.</p>' +
+        '<p>What would you like me to do?</p>';
+
+    this.emit(':ask', speech, repromptSpeech);
 };


### PR DESCRIPTION
Change launch request to ask a question at the end of explaining what it can do. Also add reprompt speech.

This fixes certification issue raised where the LaunchRequest closes the session once spoken.